### PR TITLE
feat(ask): add citation spans to grounded responses (closes #2)

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -46,9 +46,16 @@ def ask(req: AskRequest) -> AskResponse:
     for idx, doc in enumerate(matches, start=1):
         answer_lines.append(f"{idx}. {doc['text']}")
 
+    citations = [
+        {"id": m["id"], "source": m["source"], "text": m["text"]}
+        for m in matches
+    ]
+
+
     return AskResponse(
         answer="\n".join(answer_lines),
         sources=sorted({m["source"] for m in matches}),
+        citations=citations,
     )
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -11,6 +11,10 @@ class AskRequest(BaseModel):
 class AskResponse(BaseModel):
     answer: str
     sources: list[str]
+    citations: list[dict] = Field(
+        default_factory=list,
+        description="Grounded citations with source-linked spans: id, source file, and text chunk"
+    )
 
 
 class SQLSuggestRequest(BaseModel):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,18 @@ def test_health() -> None:
 def test_ask_and_sql_suggest() -> None:
     ask_res = client.post("/v1/ask", json={"question": "what is conversion_rate?", "top_k": 2})
     assert ask_res.status_code == 200
-    assert "Grounded findings" in ask_res.json()["answer"]
+    body = ask_res.json()
+    assert "Grounded findings" in body["answer"]
+    assert "sources" in body
+    assert "citations" in body
+    assert isinstance(body["citations"], list)
+    assert len(body["citations"]) > 0
+    # Each citation has required fields
+    for cit in body["citations"]:
+        assert "id" in cit
+        assert "source" in cit
+        assert "text" in cit
+        assert cit["source"] in body["sources"]
 
     sql_res = client.post("/v1/sql/suggest", json={"question": "show channel performance"})
     assert sql_res.status_code == 200


### PR DESCRIPTION
## Summary
Returns source-linked citation spans instead of just source file names in `/v1/ask` responses.

## Changes
- **models.py**: `AskResponse` now includes a `citations` list with `{id, source, text}` per match
- **routes.py**: `/v1/ask` endpoint now populates `citations` from retrieval matches
- **test_api.py**: Updated `test_ask_and_sql_suggest` to assert citation structure and field presence

## Example response
```json
{
  "answer": "Grounded findings:\n1. ...",
  "sources": ["bi_semantics.md", "kpi_definitions.md"],
  "citations": [
    {"id": "bi_semantics.md:3", "source": "bi_semantics.md", "text": "conversion_rate Formula: paid_conversions / new_users..."}
  ]
}
```

Closes #2